### PR TITLE
Update earth's radius to the UM value for consistency

### DIFF
--- a/share/patches/shr_const_mod.F90.patch
+++ b/share/patches/shr_const_mod.F90.patch
@@ -1,11 +1,17 @@
-# Copyright ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
-# SPDX-License-Identifier: Apache-2.0
-
 diff --git a/src/shr_const_mod.F90 b/src/shr_const_mod.F90
-index 8437190..9696c81 100644
---- shr_const_mod.F90.old
-+++ shr_const_mod.F90.new
-@@ -87,9 +87,8 @@ contains
+index 8437190..bd4b687 100644
+--- a/src/shr_const_mod.F90
++++ b/src/shr_const_mod.F90
+@@ -17,7 +17,7 @@ MODULE shr_const_mod
+    real(R8),parameter :: SHR_CONST_CDAY    = 86400.0_R8      ! sec in calendar day ~ sec
+    real(R8),parameter :: SHR_CONST_SDAY    = 86164.0_R8      ! sec in siderial day ~ sec
+    real(R8),parameter :: SHR_CONST_OMEGA   = 2.0_R8*SHR_CONST_PI/SHR_CONST_SDAY ! earth rot ~ rad/sec
+-   real(R8),parameter :: SHR_CONST_REARTH  = 6.37122e6_R8    ! radius of earth ~ m
++   real(R8),parameter :: SHR_CONST_REARTH  = 6.371229e6_R8   ! radius of earth used by UM13 ~ m
+    real(R8),parameter :: SHR_CONST_G       = 9.80616_R8      ! acceleration of gravity ~ m/s^2
+ 
+    real(R8),parameter :: SHR_CONST_STEBOL  = 5.67e-8_R8      ! Stefan-Boltzmann constant ~ W/m^2/K^4
+@@ -87,7 +87,6 @@ contains
  !-----------------------------------------------------------------------------
  
    elemental logical function shr_const_isspval(rval)
@@ -13,5 +19,3 @@ index 8437190..9696c81 100644
  
       real(r8), intent(in) :: rval
  
-      if (rval > SHR_CONST_SPVAL_TOLMIN .and. &
-          rval < SHR_CONST_SPVAL_TOLMAX) then


### PR DESCRIPTION
Per https://github.com/ACCESS-NRI/access-om3-configs/issues/417#issuecomment-2750111032, set earths's radius consistently between components

n.b. SHR_CONST_REARTH is used in the mediator and and CICE6. It is set elsewhere (to the same value) for MOM6 and the UM.