### PR TITLE
experiments with build-ci

### DIFF
--- a/.github/build-ci/data/standard.json
+++ b/.github/build-ci/data/standard.json
@@ -1,0 +1,7 @@
+{
+    "gcc_compiler": "gcc@13.2.0",
+    "intel_compiler": "intel@2021.10.0",
+    "oneapi_compiler": "oneapi@2025.2.0",
+    "target": "x86_64",
+    "all_configurations": "MOM6,CICE6,WW3,MOM6-WW3,MOM6-CICE6,CICE6-WW3,MOM6-CICE6-WW3"
+}

--- a/.github/build-ci/manifests/gcc.spack.yaml.j2
+++ b/.github/build-ci/manifests/gcc.spack.yaml.j2
@@ -1,0 +1,13 @@
+spack:
+  specs:
+  - access3 @git.{{ ref }} configurations={{ all_configurations }}
+  packages:
+    access3-share:
+      require:
+        '@git.{{ ref }}=stable'
+    all:
+      require:
+      - '%{{ gcc_compiler }} target={{ target }}'
+  concretizer:
+    unify: false
+  view: false

--- a/.github/build-ci/manifests/intel-libonly.spack.yaml.j2
+++ b/.github/build-ci/manifests/intel-libonly.spack.yaml.j2
@@ -1,0 +1,11 @@
+spack:
+  specs:
+  - access3-share @git.{{ ref }}
+  - access3-share @git.{{ ref }} +openmp
+  packages:
+    all:
+      require:
+      - '%{{ intel_compiler }} target={{ target }}'
+  concretizer:
+    unify: false
+  view: false

--- a/.github/build-ci/manifests/intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/intel.spack.yaml.j2
@@ -1,7 +1,6 @@
 spack:
   specs:
   - access3 @git.{{ ref }} configurations={{ all_configurations }}
-  - access3 @git.{{ ref }} configurations={{ all_configurations }} +openmp
   packages:
     all:
       require:

--- a/.github/build-ci/manifests/intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/intel.spack.yaml.j2
@@ -2,6 +2,9 @@ spack:
   specs:
   - access3 @git.{{ ref }} configurations={{ all_configurations }}
   packages:
+    access3-share:
+      require:
+        @git.{{ ref }}=stable
     all:
       require:
       - '%{{ intel_compiler }} target={{ target }}'

--- a/.github/build-ci/manifests/intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/intel.spack.yaml.j2
@@ -1,0 +1,11 @@
+spack:
+  specs:
+  - access3 @git.{{ ref }} configurations={{ all_configurations }}
+  - access3 @git.{{ ref }} configurations={{ all_configurations }} +openmp
+  packages:
+    all:
+      require:
+      - '%{{ intel_compiler }} target={{ target }}'
+  concretizer:
+    unify: false
+  view: false

--- a/.github/build-ci/manifests/intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/intel.spack.yaml.j2
@@ -4,7 +4,7 @@ spack:
   packages:
     access3-share:
       require:
-        @git.{{ ref }}=stable
+        '@git.{{ ref }}=stable'
     all:
       require:
       - '%{{ intel_compiler }} target={{ target }}'

--- a/.github/build-ci/manifests/oneapi.spack.yaml.j2
+++ b/.github/build-ci/manifests/oneapi.spack.yaml.j2
@@ -1,0 +1,13 @@
+spack:
+  specs:
+  - access3 @git.{{ ref }} configurations={{ all_configurations }}
+  packages:
+    access3-share:
+      require:
+        '@git.{{ ref }}=stable'
+    all:
+      require:
+      - '%{{ oneapi_compiler }} target={{ target }}'
+  concretizer:
+    unify: false
+  view: false

--- a/.github/build-ci/manifests/oneapi.spack.yaml.j2
+++ b/.github/build-ci/manifests/oneapi.spack.yaml.j2
@@ -5,6 +5,9 @@ spack:
     access3-share:
       require:
         '@git.{{ ref }}=stable'
+    gcc-runtime:
+      require:
+        '%gcc'
     all:
       require:
       - '%{{ oneapi_compiler }} target={{ target }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: Build
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - dev/*
+jobs:
+  pre-ci:
+    name: Pre-CI
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up matrix
+        id: set-matrix
+        # Find all relevant files under .github/build-ci/manifests
+        # then output them as a JSON array (minus the last comma)
+        run: |
+          files=$(find .github/build-ci/manifests/ -iname '*.j2' -printf '"%p",')
+          echo "matrix=[${files%,}]" >> $GITHUB_OUTPUT
+
+  ci:
+    name: CI
+    needs: pre-ci
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix:
+        file: ${{ fromJson(needs.pre-ci.outputs.matrix) }}
+    uses: access-nri/build-ci/.github/workflows/ci.yml@v2
+    with:
+      spack-manifest-path: ${{ matrix.file }}
+      allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
+      spack-manifest-data-path: .github/build-ci/data/standard.json
+      # spack-packages-ref: main
+      # spack-config-ref: main
+      # spack-ref: releases/v0.22


### PR DESCRIPTION
Closes #8 

adds build-CI


Do a full build of access-om3 for all configurations and all variants.

Do a build of access3-share library only as well, to assist in debugging.